### PR TITLE
Incorrect values set in `CURLOPT_HTTP_VERSION`

### DIFF
--- a/src/CurlHttpClient.php
+++ b/src/CurlHttpClient.php
@@ -226,7 +226,7 @@ class CurlHttpClient extends AbstractHttpClient
         $options[CURLOPT_HEADER] = true;
         $options[CURLOPT_RETURNTRANSFER] = true;
 
-        $options[CURLOPT_HTTP_VERSION] = $request->getProtocolVersion();
+        $options[CURLOPT_HTTP_VERSION] = $this->getProtocolVersion($request->getProtocolVersion());
         $options[CURLOPT_URL] = (string) $request->getUri();
 
         $options[CURLOPT_CONNECTTIMEOUT] = $this->options['connection_timeout'];
@@ -272,5 +272,15 @@ class CurlHttpClient extends AbstractHttpClient
         }
 
         return $options;
+    }
+
+    private function getProtocolVersion($requestVersion)
+    {
+        switch ($requestVersion) {
+            case "1.0": return CURL_HTTP_VERSION_1_0;
+            case "1.1": return CURL_HTTP_VERSION_1_1;
+            case "2.0": throw new \UnexpectedValueException('2.0 not supported');
+            default:    return CURL_HTTP_VERSION_NONE;
+        }
     }
 }


### PR DESCRIPTION
`CURLOPT_HTTP_VERSION` should use `CURL_HTTP_VERSION_1_*` constants, not the raw string coming out of `MessageInterface->getProtocolVersion()`.

```php
$rq = (new Psr\HttpImpl\Request)
    ->withProtocolVersion("1.1")
    ->withMethod('GET')
    ->withUrl('http://localhost/test.php');
$rs = $httpClient->send($rq);
```

From `ngrep`, we can see that the invalid string "1.1" is being turned by Curl into `HTTP/1.0`:
```
$ sudo ngrep -q -d lo -W byline host localhost and port 80
interface: lo (127.0.0.0/255.0.0.0)
filter: (ip or ip6) and ( host localhost and port 80 )

T 127.0.0.1:46958 -> 127.0.0.1:80 [AP]
GET /test.php HTTP/1.0.
Accept: */*.
Host: localhost.
```