### PR TITLE
HTTP appearing in result of getProtocolVersion()

### DIFF
--- a/src/CurlHttpClient.php
+++ b/src/CurlHttpClient.php
@@ -80,7 +80,7 @@ class CurlHttpClient extends AbstractHttpClient
                 $parts = explode(' ', $header, 3);
                 $response = $response
                     ->withStatus($parts[1])
-                    ->withProtocolVersion($parts[0]);
+                    ->withProtocolVersion(substr($parts[0], 5));
                 continue;
             }
             // Extract header

--- a/tests/CurlHttpClientDiactorosTest.php
+++ b/tests/CurlHttpClientDiactorosTest.php
@@ -33,6 +33,7 @@ class CurlHttpClientDiactorosTest extends TestCase
         $request = $request->withHeader('Accept-Encoding', 'text/html');
         $response = $client->sendRequest($request);
         static::assertEquals(200, $response->getStatusCode());
+        static::assertEquals('1.1', $response->getProtocolVersion());
         static::assertEquals(['text/html'], $response->getHeader('Content-type'));
         static::assertContains('Example Domain', $response->getBody()->getContents());
     }


### PR DESCRIPTION
When I dump out a `Zend\Diactoros`Response` object, I see `HTTP/HTTP/1.1 200 OK` as the status line.

The extra `HTTP/` is coming from `CurlHttpClient` - it should be chopped off to conform to the spec:

> The string MUST contain only the HTTP version number (e.g., "1.1", "1.0").